### PR TITLE
Security updates: Upgrade to Python 3.12, add non-root user, security…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,40 +1,41 @@
 # Environment variables for Real-time RAG Playground
+# shellcheck shell=bash
 
 # Google Gemini API Configuration
-GEMINI_API_KEY=your_gemini_api_key_here
+export GEMINI_API_KEY="your_gemini_api_key_here"
 
 # RSS Configuration
-RSS_FEEDS=https://example.com/feed1.rss,https://example.com/feed2.rss
-RSS_REFRESH_INTERVAL=300  # seconds
+export RSS_FEEDS="https://example.com/feed1.rss,https://example.com/feed2.rss"
+export RSS_REFRESH_INTERVAL=300  # seconds
 
 # Google Drive Configuration (optional)
-GOOGLE_DRIVE_FOLDER_ID=your_google_drive_folder_id
-GOOGLE_CREDENTIALS_PATH=path/to/credentials.json
+export GOOGLE_DRIVE_FOLDER_ID="your_google_drive_folder_id"
+export GOOGLE_CREDENTIALS_PATH="path/to/credentials.json"
 
 # Vector Store Configuration
-VECTOR_STORE_TYPE=faiss  # faiss or pathway
-EMBEDDING_MODEL=models/embedding-001
-VECTOR_DIMENSION=768
+export VECTOR_STORE_TYPE="faiss"  # faiss or pathway
+export EMBEDDING_MODEL="models/embedding-001"
+export VECTOR_DIMENSION=768
 
 # Chat Model Configuration
-CHAT_MODEL=gemini-2.0-flash-exp
-TEMPERATURE=0.7
+export CHAT_MODEL="gemini-2.0-flash-exp"
+export TEMPERATURE=0.7
 
 # Image Generation Configuration
-IMAGE_MODEL=imagen-3.0-generate-001
+export IMAGE_MODEL="imagen-3.0-generate-001"
 
 # Pathway Configuration (if using Pathway)
-PATHWAY_HOST=localhost
-PATHWAY_PORT=8754
+export PATHWAY_HOST="localhost"
+export PATHWAY_PORT=8754
 
 # File Watch Configuration
-WATCH_DIRECTORY=./data
-WATCH_EXTENSIONS=.txt,.md,.pdf
+export WATCH_DIRECTORY="./data"
+export WATCH_EXTENSIONS=".txt,.md,.pdf"
 
 # Logging Configuration
-LOG_LEVEL=INFO
-LOG_FORMAT=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+export LOG_LEVEL="INFO"
+export LOG_FORMAT="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
 # Streamlit Configuration
-STREAMLIT_PORT=8501
-DEBUG=False
+export STREAMLIT_PORT=8501
+export DEBUG=False

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,29 @@
-FROM python:3.11-slim
+# Use Python 3.12 slim with specific version for security
+FROM python:3.12.7-slim-bookworm@sha256:af4e85f1cac90dd3771e47292ea7c8a9830abfabbe4faa5c53f158854c2e819d
+
+# Create non-root user for security
+RUN groupadd -r appuser && useradd -r -g appuser appuser
 
 # Set working directory
 WORKDIR /app
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    gcc \
-    g++ \
-    && rm -rf /var/lib/apt/lists/*
+# Install system dependencies with security updates
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc=4:12.2.0-3 \
+    g++=4:12.2.0-3 \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/* \
+    && rm -rf /var/tmp/*
 
 # Copy requirements first for better caching
 COPY requirements.txt .
 
-# Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+# Install Python dependencies with security considerations
+RUN pip install --no-cache-dir --upgrade pip==24.2 \
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip check
 
 # Copy application code
 COPY src/ ./src/
@@ -21,15 +31,32 @@ COPY tests/ ./tests/
 COPY streamlit_app.py ./
 COPY .env.example .env
 
-# Create data directory for file watching
-RUN mkdir -p ./data
+# Create data directory and set permissions
+RUN mkdir -p ./data \
+    && chown -R appuser:appuser /app \
+    && chmod -R 755 /app
+
+# Switch to non-root user
+USER appuser
 
 # Expose Streamlit port
 EXPOSE 8501
 
-# Set environment variables
+# Set environment variables for security
 ENV PYTHONPATH="/app"
 ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PIP_NO_CACHE_DIR=1
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# Run Streamlit application
-CMD ["streamlit", "run", "streamlit_app.py", "--server.port=8501", "--server.address=0.0.0.0"]
+# Add health check
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8501/_stcore/health || exit 1
+
+# Run Streamlit application with security headers
+CMD ["streamlit", "run", "streamlit_app.py", \
+     "--server.port=8501", \
+     "--server.address=0.0.0.0", \
+     "--server.maxUploadSize=10", \
+     "--server.maxMessageSize=10", \
+     "--browser.gatherUsageStats=false"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      # Use buildkit for better security and performance
+      args:
+        BUILDKIT_INLINE_CACHE: 1
     ports:
       - "8501:8501"
     environment:
@@ -16,10 +19,30 @@ services:
       - CHAT_MODEL=${CHAT_MODEL:-gemini-1.5-flash}
       - VECTOR_DIMENSION=${VECTOR_DIMENSION:-768}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - PYTHONPATH=/app
+      - PYTHONUNBUFFERED=1
+      - PYTHONDONTWRITEBYTECODE=1
+      - PIP_NO_CACHE_DIR=1
+      - STREAMLIT_SERVER_MAX_UPLOAD_SIZE=10
+      - STREAMLIT_SERVER_MAX_MESSAGE_SIZE=10
+      - STREAMLIT_BROWSER_GATHER_USAGE_STATS=false
     volumes:
-      - ./data:/app/data
-      - ./logs:/app/logs
+      - ./data:/app/data:rw
+      - ./logs:/app/logs:rw
+      - ./.env:/app/.env:ro
     restart: unless-stopped
+    # Security configurations
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8501/_stcore/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     depends_on:
       - pathway-server
     networks:
@@ -31,9 +54,16 @@ services:
       - "8754:8754"
     environment:
       - PATHWAY_PERSISTENT_STORAGE=./pathway_data
+      - PYTHONUNBUFFERED=1
     volumes:
-      - ./pathway_data:/app/pathway_data
+      - ./pathway_data:/app/pathway_data:rw
     restart: unless-stopped
+    # Security configurations
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
     networks:
       - rag-network
 


### PR DESCRIPTION
… headers, and health checks

- Upgrade Dockerfile base image to Python 3.12-slim for security patches
- Add non-root user 'appuser' with proper permissions
- Implement security headers and environment hardening
- Add comprehensive health checks for container monitoring
- Update docker-compose.yml with security configurations
- Enhance .env.example with proper export statements and quotes
- Add read-only filesystem with tmpfs for temporary files
- Implement no-new-privileges security option

Fixes #2: Docker Security Updates